### PR TITLE
fix harmony_integrate TypeError under RMM managed memory

### DIFF
--- a/src/rapids_singlecell/preprocessing/_harmony/__init__.py
+++ b/src/rapids_singlecell/preprocessing/_harmony/__init__.py
@@ -350,7 +350,7 @@ def harmonize(
             n_batches=n_joint_categories,
         )
 
-    empty_int = cp.empty(0, dtype=cp.int32)
+    empty_int = cats[:0]
 
     # Main harmony iterations
     is_converged = False

--- a/tests/test_managed_memory.py
+++ b/tests/test_managed_memory.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import cupy as cp
 import numpy as np
+import pandas as pd
 import pytest
 import rmm
 from anndata import AnnData
@@ -74,3 +75,14 @@ def test_qc_metrics(managed_memory):
     rsc.pp.calculate_qc_metrics(adata, log1p=False)
     assert "total_counts" in adata.obs.columns
     assert "n_genes_by_counts" in adata.obs.columns
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_harmony_integrate(managed_memory, dtype):
+    """Regression test for GH-763: harmony_integrate with managed memory"""
+    rng = np.random.default_rng(0)
+    adata = AnnData(rng.standard_normal((300, 5)).astype(np.float32))
+    adata.obs["batch"] = pd.Categorical(rng.choice(["a", "b"], 300))
+    adata.obsm["X_pca"] = rng.standard_normal((300, 10))
+    rsc.pp.harmony_integrate(adata, key="batch")
+    assert adata.obsm["X_pca_harmony"].shape == (300, 10)


### PR DESCRIPTION
Fixes #763 
With a single batch key, the zero-size joint placeholder arrays own no allocation, so they report kDLCUDA while every other argument under rmm managed memory reports kDLCUDAManaged. No clustering_loop overload matches. 
Using a zero-length view of cats keeps the memory kind consistent under any allocator. Verified on 0.16.1 hardware by applying the change to the installed package and rerunning the repro from 763
Added test_managed_memory.py